### PR TITLE
Do not throw error just pass it to callback

### DIFF
--- a/lib/redisdriver.js
+++ b/lib/redisdriver.js
@@ -162,7 +162,7 @@ RedisDriver.prototype.atomicSubmit = function(cName, docName, opData, options, c
           // In this case, we should write a no-op ramp to the snapshot
           // version, followed by a delete & a create to fill in the missing
           // ops.
-          throw Error('Missing oplog for ' + cName + ' ' + docName);
+          return callback('Missing oplog for ' + cName + ' ' + docName);
         }
         self._redisSubmitScript(cName, docName, opData, version, callbackWrapper);
       });


### PR DESCRIPTION
Pass missing oplog as error to top do not throw error, because it is not show error to user
